### PR TITLE
Fix/job owner upload photo and password reset redirect

### DIFF
--- a/apps/freelance/src/pages/PasswordReset/usePasswordReset.ts
+++ b/apps/freelance/src/pages/PasswordReset/usePasswordReset.ts
@@ -5,7 +5,8 @@ import {
   useForm,
   UseFormHandleSubmit,
 } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { routes } from '@freelance/constants';
 import { SerializedError } from '@reduxjs/toolkit';
 import {
   usePasswordResetCheckAvailabilityQuery,
@@ -35,10 +36,17 @@ const usePasswordReset = (): UsePasswordResetResponse => {
   const { data: linkValid } = usePasswordResetCheckAvailabilityQuery(key || '');
   const [passwordReset, { isLoading, isSuccess, isError, error }] =
     usePasswordResetMutation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     setIsLinkValid(linkValid);
   }, [linkValid]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      navigate(routes.login);
+    }
+  }, [isSuccess]);
 
   const onSubmit: SubmitHandler<Inputs> = data => {
     passwordReset({ password: data.password, key: key || '' });

--- a/apps/freelance/src/pages/PasswordReset/usePasswordReset.ts
+++ b/apps/freelance/src/pages/PasswordReset/usePasswordReset.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { message } from 'antd';
+import { t } from 'i18next';
 import {
   Control,
   SubmitHandler,
@@ -44,6 +46,7 @@ const usePasswordReset = (): UsePasswordResetResponse => {
 
   useEffect(() => {
     if (isSuccess) {
+      message.success(t('resetPassword.successResetMessage'));
       navigate(routes.login);
     }
   }, [isSuccess]);

--- a/apps/freelance/src/translations/en/translation/offers.ts
+++ b/apps/freelance/src/translations/en/translation/offers.ts
@@ -7,8 +7,8 @@ export default {
     buttons: {
       acceptOffer: 'Accept offer',
       declineOffer: 'Decline offer',
-      chat: 'chat',
-      deleteInterview: 'delete invitation',
+      chat: 'Chat',
+      deleteInterview: 'Delete invitation',
     },
     hrly_rate: '$ {{rate}} / hr',
     sortOptions: {

--- a/libs/components/src/lib/avatar-upload/index.tsx
+++ b/libs/components/src/lib/avatar-upload/index.tsx
@@ -11,9 +11,15 @@ import { beforeUpload } from './utils';
 
 interface AvatarUploadProps {
   src?: string;
+  size?: number;
+  hideUploadText?: boolean;
 }
 
-export const AvatarUpload: FC<AvatarUploadProps> = ({ src }) => {
+export const AvatarUpload: FC<AvatarUploadProps> = ({
+  src,
+  size,
+  hideUploadText,
+}) => {
   const { t } = useTranslation();
   const { imageUrl, uploadImage } = useProfileImage(src);
 
@@ -33,10 +39,12 @@ export const AvatarUpload: FC<AvatarUploadProps> = ({ src }) => {
       >
         <Avatar
           icon={<UserOutlined />}
-          size={avatarSize}
+          size={size || avatarSize}
           src={imageUrl ? imageUrl : null}
         />
-        <StyledUploadLine>{t('uploadImage.uploadText')}</StyledUploadLine>
+        {!hideUploadText && (
+          <StyledUploadLine>{t('uploadImage.uploadText')}</StyledUploadLine>
+        )}
       </StyledUpload>
     </ImgCrop>
   );

--- a/libs/components/src/lib/avatar-upload/useProfileImage.ts
+++ b/libs/components/src/lib/avatar-upload/useProfileImage.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useSetProfileImageMutation } from 'src/redux/services/user';
+import { getFileUrl } from 'src/utils/api';
 
 import { uploadName } from './constants';
 import { CustomRequestOptions } from './types';
@@ -15,9 +16,13 @@ const useProfileImage = (src?: string): useProfileImageReturn => {
 
   useEffect(() => {
     if (data?.file) {
-      setImageUrl(`${process.env['NX_API_URL']}/${data.file}`);
+      setImageUrl(getFileUrl(data.file));
     }
   }, [data]);
+
+  useEffect(() => {
+    setImageUrl(src || '');
+  }, [src]);
 
   const uploadImage = (options: CustomRequestOptions): void => {
     const { file } = options;

--- a/libs/components/src/lib/navigation-bar/constants.ts
+++ b/libs/components/src/lib/navigation-bar/constants.ts
@@ -1,0 +1,1 @@
+export const avatarSize = 45;

--- a/libs/components/src/lib/navigation-bar/index.tsx
+++ b/libs/components/src/lib/navigation-bar/index.tsx
@@ -1,4 +1,4 @@
-import { Avatar, roles } from '@freelance/components';
+import { AvatarUpload, roles } from '@freelance/components';
 import { getFileUrl } from 'src/utils/api';
 
 import {
@@ -18,7 +18,11 @@ export const NavigationBar = () => {
   return (
     <Container>
       <UserContainer>
-        <Avatar src={getFileUrl(user?.profile_image)} />
+        <AvatarUpload
+          src={getFileUrl(user?.profile_image)}
+          hideUploadText={true}
+          size={45}
+        />
         <UsernameContainer>
           <UserName>{`${user?.first_name || ''} ${
             user?.last_name || ''

--- a/libs/components/src/lib/navigation-bar/index.tsx
+++ b/libs/components/src/lib/navigation-bar/index.tsx
@@ -1,6 +1,7 @@
 import { AvatarUpload, roles } from '@freelance/components';
 import { getFileUrl } from 'src/utils/api';
 
+import { avatarSize } from './constants';
 import {
   BarItem,
   BarItemsContainer,
@@ -21,7 +22,7 @@ export const NavigationBar = () => {
         <AvatarUpload
           src={getFileUrl(user?.profile_image)}
           hideUploadText={true}
-          size={45}
+          size={avatarSize}
         />
         <UsernameContainer>
           <UserName>{`${user?.first_name || ''} ${


### PR DESCRIPTION
added upload new profile image by clicking on user's avatar on navigation bar. because we don't have job owner profile page where we can set it.
added redirect to login page after password reset

![image](https://user-images.githubusercontent.com/102069411/209226476-061b864c-ff0b-4ab9-8b6f-d16fdb1835c4.png)

![image](https://user-images.githubusercontent.com/102069411/209226525-ecdc97c4-ac6c-43dd-a1f7-302b52ff9260.png)

![image](https://user-images.githubusercontent.com/102069411/209226549-661f80d1-cc33-40ac-895d-c1daedf59d37.png)
