### PR TITLE
Fix/profile questions

### DIFF
--- a/apps/freelance/src/pages/FreelancerEditProfile/FreelancerProfile.spec.tsx
+++ b/apps/freelance/src/pages/FreelancerEditProfile/FreelancerProfile.spec.tsx
@@ -36,7 +36,7 @@ jest.mock('redux/services/user', () => ({
   useAddUserWorkhistoryInfoMutation: () => [AddUserWorkhistory],
 }));
 
-describe('FreelancerPageInfo rendering component using data from rtk query', () => {
+describe('FreelancerProfile rendering component using data from rtk query', () => {
   const container: Element = document.createElement('div');
 
   beforeAll(() => {

--- a/apps/freelance/src/pages/FreelancerEditProfile/FreelancerProfile.spec.tsx
+++ b/apps/freelance/src/pages/FreelancerEditProfile/FreelancerProfile.spec.tsx
@@ -1,0 +1,84 @@
+import { unmountComponentAtNode } from 'react-dom';
+import {
+  freelancerProfile,
+  mockFreelacerEducation,
+  mockFreelancerProfileData,
+  mockFreelancerWH,
+} from '@freelance/components';
+import { render, screen } from '@utils/test-utils';
+import {
+  AddEducation,
+  AddWorkhistory,
+  UpdateUser,
+} from 'redux/types/user.types';
+
+import '@testing-library/jest-dom';
+
+import FreelancerProfile from './index';
+
+const UpdateUserInfo = (userPayload: UpdateUser) => userPayload;
+const AddUserEduInfo = (educationPayloadArr: AddEducation[]) =>
+  educationPayloadArr;
+const AddUserWorkhistory = (workPayloadArr: AddWorkhistory[]) => workPayloadArr;
+
+jest.mock('redux/services/user', () => ({
+  useGetUserInfoQuery: () => ({
+    data: mockFreelancerProfileData,
+    isLoading: false,
+  }),
+  useGetUserWorkInfoQuery: () => ({ data: mockFreelancerWH, isLoading: false }),
+  useGetUserEducationInfoQuery: () => ({
+    data: mockFreelacerEducation,
+    isLoading: false,
+  }),
+  useUpdateUserInfoMutation: () => [UpdateUserInfo],
+  useAddUserEduInfoMutation: () => [AddUserEduInfo],
+  useAddUserWorkhistoryInfoMutation: () => [AddUserWorkhistory],
+}));
+
+describe('FreelancerPageInfo rendering component using data from rtk query', () => {
+  const container: Element = document.createElement('div');
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    unmountComponentAtNode(container);
+    container.remove();
+  });
+
+  it('renders a component FreelancerProfile', () => {
+    const baseElement = render(<FreelancerProfile />);
+
+    expect(baseElement).toBeTruthy();
+  });
+
+  it('field with freelancer data displays correct data from rtk query', () => {
+    render(<FreelancerProfile />);
+
+    expect(screen.getByTestId(freelancerProfile.profileImage).textContent).toBe(
+      `${mockFreelancerProfileData.first_name} ${mockFreelancerProfileData.last_name}`,
+    );
+
+    expect(screen.getByTestId(freelancerProfile.email).textContent).toBe(
+      `${mockFreelancerProfileData?.email}`,
+    );
+  });
+});

--- a/apps/freelance/src/pages/FreelancerEditProfile/index.tsx
+++ b/apps/freelance/src/pages/FreelancerEditProfile/index.tsx
@@ -1,13 +1,14 @@
 import { Avatar } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { UserOutlined } from '@ant-design/icons';
-import { baseUrl, profileQ1 } from '@freelance/components';
+import { baseUrl, freelancerProfile, profileQ1 } from '@freelance/components';
 import { AvatarUpload, FreelancerForm } from '@freelance/components';
 import {
   useGetUserEducationInfoQuery,
   useGetUserInfoQuery,
   useGetUserWorkInfoQuery,
 } from 'redux/services/user';
+import { baseTheme } from 'src/styles/theme';
 
 import * as St from './styles';
 
@@ -20,7 +21,7 @@ const FreelancerProfile = () => {
 
   return (
     <St.Wrapper isLoading={isLoadingUser || isLoadingWork || isLoadingEdu}>
-      <St.LogoWrapper direction="vertical">
+      <St.LogoWrapper theme={baseTheme} direction="vertical">
         {user?.profile_image ? (
           <Avatar
             src={`${baseUrl}/${user?.profile_image}`}
@@ -30,10 +31,10 @@ const FreelancerProfile = () => {
         ) : (
           <AvatarUpload />
         )}
-        <p>
+        <p data-testid={freelancerProfile.profileImage}>
           {user?.first_name} {user?.last_name}
         </p>
-        <p>{user?.email}</p>
+        <p data-testid={freelancerProfile.email}>{user?.email}</p>
       </St.LogoWrapper>
       <FreelancerForm
         submitText={t('description.freelancerEditProfile.save')}

--- a/apps/freelance/src/translations/en/translation/description.ts
+++ b/apps/freelance/src/translations/en/translation/description.ts
@@ -13,7 +13,8 @@ export default {
     profileQp1: {
       pr_bar_completion_per: '20% completed',
       upload_profile_photo: 'Upload Profile Photo',
-      add_one_more: 'Add one more',
+      add_education: 'Add Education',
+      add_workhistory: 'Add Workhistory',
       hR: 'Hourly Rate',
       hRPrefix: '$',
       hRSuffix: 'Per hour',

--- a/libs/components/src/lib/constants/mockUserData.ts
+++ b/libs/components/src/lib/constants/mockUserData.ts
@@ -1,5 +1,11 @@
 import { FreelancerDataById } from 'src/redux/types/freelancers.types';
-import { AddEducation, AddWorkhistory, User } from 'src/redux/types/user.types';
+import {
+  AddEducation,
+  AddWorkhistory,
+  GetEducation,
+  GetWorkhistory,
+  User,
+} from 'src/redux/types/user.types';
 
 export interface mockWork extends AddWorkhistory {
   id?: number;
@@ -83,4 +89,48 @@ export const mockUsers: User[] = [
     last_name: 'Powers',
     profile_image: 'img/660ba6e4-557b-4033-8779-656ea304f342.jpg',
   } as User,
+];
+
+export const mockFreelancerProfileData: User = {
+  id: 123,
+  email: 'test@test.com',
+  first_name: 'John',
+  last_name: 'Doe',
+  profile_image: 'https://localhost:4200/image.img',
+  role: 'Freelancer',
+  available_time: 'Full-Time',
+  description: 'Front-end developer',
+  position: 'Front-end developer',
+  hourly_rate: 30,
+  other_experience: 'English teacher',
+  english_level: 'Upper-Intermediate',
+  category: {
+    id: 1,
+    name: 'Front-end development',
+  },
+  skills: [
+    {
+      id: 1,
+      name: 'HTML',
+    },
+  ],
+};
+
+export const mockFreelancerWH: GetWorkhistory[] = [
+  {
+    id: 1,
+    work_history_descr: 'Full-Stack Developer at Apple inc',
+    work_history_from: '2016',
+    work_history_to: '2022',
+  },
+];
+
+export const mockFreelacerEducation: GetEducation[] = [
+  {
+    id: 1,
+    education_descr:
+      'Bachelors in International Business Administration. LCC IU',
+    education_from: '2010',
+    education_to: '2014',
+  },
 ];

--- a/libs/components/src/lib/constants/testIds.ts
+++ b/libs/components/src/lib/constants/testIds.ts
@@ -15,6 +15,11 @@ export const freelancerPageInfo = {
   skills: 'fpiskillsArr',
 };
 
+export const freelancerProfile = {
+  profileImage: 'fpprofileImage',
+  email: 'fpemail',
+};
+
 export const findJobsPageTestId = {
   totalCount: 'findJobsTtotalCount',
   filterButton: 'findJobsFilterButton',

--- a/libs/components/src/lib/freelancer-profile-form/FormEduList.tsx
+++ b/libs/components/src/lib/freelancer-profile-form/FormEduList.tsx
@@ -19,7 +19,7 @@ const FormEduList: FC<freelancerEduProps> = ({ education }) => {
     <Form.List
       name={profileQ1.edu}
       initialValue={
-        (education && convertEduTime(education)) || profileQ1.workEduDefValue
+        profileQ1.workEduDefValue || (education && convertEduTime(education))
       }
     >
       {(fields, { add, remove }) => (

--- a/libs/components/src/lib/freelancer-profile-form/FormEduList.tsx
+++ b/libs/components/src/lib/freelancer-profile-form/FormEduList.tsx
@@ -19,7 +19,7 @@ const FormEduList: FC<freelancerEduProps> = ({ education }) => {
     <Form.List
       name={profileQ1.edu}
       initialValue={
-        profileQ1.workEduDefValue || (education && convertEduTime(education))
+        (education && convertEduTime(education)) || profileQ1.workEduDefValue
       }
     >
       {(fields, { add, remove }) => (
@@ -86,7 +86,7 @@ const FormEduList: FC<freelancerEduProps> = ({ education }) => {
           ))}
           <Form.Item>
             <Button type="dashed" onClick={add} block icon={<PlusOutlined />}>
-              {t('description.profileQp1.add_one_more')}
+              {t('description.profileQp1.add_workhistory')}
             </Button>
           </Form.Item>
         </>

--- a/libs/components/src/lib/freelancer-profile-form/FormWorkList.tsx
+++ b/libs/components/src/lib/freelancer-profile-form/FormWorkList.tsx
@@ -19,7 +19,7 @@ const FormWorkList: FC<freelancerWorkProps> = ({ work }) => {
     <Form.List
       name={profileQ1.workHistoryWrapper}
       initialValue={
-        (work && convertWorkTime(work)) || profileQ1.workEduDefValue
+        profileQ1.workEduDefValue || (work && convertWorkTime(work))
       }
     >
       {(fields, { add, remove }) => (

--- a/libs/components/src/lib/freelancer-profile-form/FormWorkList.tsx
+++ b/libs/components/src/lib/freelancer-profile-form/FormWorkList.tsx
@@ -19,7 +19,7 @@ const FormWorkList: FC<freelancerWorkProps> = ({ work }) => {
     <Form.List
       name={profileQ1.workHistoryWrapper}
       initialValue={
-        profileQ1.workEduDefValue || (work && convertWorkTime(work))
+        (work && convertWorkTime(work)) || profileQ1.workEduDefValue
       }
     >
       {(fields, { add, remove }) => (
@@ -71,7 +71,7 @@ const FormWorkList: FC<freelancerWorkProps> = ({ work }) => {
           ))}
           <Form.Item>
             <Button type="dashed" onClick={add} block icon={<PlusOutlined />}>
-              {t('description.profileQp1.add_one_more')}
+              {t('description.profileQp1.add_education')}
             </Button>
           </Form.Item>
         </>


### PR DESCRIPTION
fix rare edge case bug that when freelancer doesn't add any data, he/she doesn't understand where is education and work history field (he goes straight to the my-profile without filling information form). Now buttons that add them are easier to understand (renamed buttons)

and in order to make PR more meaningful added few tests (more will be added later)
![image](https://user-images.githubusercontent.com/95277626/210006106-b4102d66-4e04-4bf5-a5af-808357d75f7f.png)
